### PR TITLE
Use Baretest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+pnpm-lock.yaml

--- a/package.json
+++ b/package.json
@@ -18,6 +18,6 @@
   "author": "Parsha Pourkhomami",
   "license": "Public Domain",
   "devDependencies": {
-    "tape": "^2.10.2"
+    "baretest": "^2.0.0"
   }
 }

--- a/test.js
+++ b/test.js
@@ -1,8 +1,8 @@
 "use strict";
 
-var test = require("tape");
-var assert = require("assert");
-var map = require("./");
+const test = require("baretest")(require('./package.json').name);
+const assert = require("assert");
+const map = require("./");
 
 test("should map object", function(t) {
 	var obj = map({ foo: 2, bar: 5 }, function(val) {
@@ -12,3 +12,5 @@ test("should map object", function(t) {
 	assert(obj.foo === 4);
 	assert(obj.bar === 10);
 });
+
+test.run()


### PR DESCRIPTION
The reason why I switched is because I get this message with the current testing library:
```
$ node test
TAP version 13
# should map object
not ok 1 test exited without ending
  ---
    operator: fail
  ...

1..1
# tests 1
# pass  0
# fail  1
```